### PR TITLE
change how osgviz singleton is created to fix segfault on close

### DIFF
--- a/src/OsgViz.cpp
+++ b/src/OsgViz.cpp
@@ -10,8 +10,6 @@
 #include <osgDB/WriteFile>
 #include <osgDB/Registry>
 
-#include <osgText/Font>
-
 #include "windows/WindowManager.h"
 #include "tools/TypeNameDemangling.h"
 
@@ -20,8 +18,7 @@ namespace osgviz
 
 std::map<std::string, Module*> OsgViz::modules;
 
-osg::ref_ptr<OsgViz> OsgViz::getInstance(){
-    
+osg::ref_ptr<OsgViz> OsgViz::getInstance(int argc,char** argv){
     //HACK to work around a static destruction order bug: default font needs to be initialized before
     //     OsgViz. Calling getDefaultFont() here ensures that the font is instanciated before 
     //     OsgViz and thus lives longer than OsgViz and can still be called during OsgViz destruction.
@@ -30,34 +27,58 @@ osg::ref_ptr<OsgViz> OsgViz::getInstance(){
     //     control static initialization/destruction order.
     //     If instance is global the static initialization order depends on the order in which 
     //     libraries are loaded which leads to strange crashes in combination with osg's own singletons
-    static osg::ref_ptr<OsgViz> instance = new OsgViz();
+    static osg::ref_ptr<OsgViz> instance = new OsgViz(argc, argv);
     return instance;
 }
 
 
-OsgViz::OsgViz() : root(new osg::Group()), thread(NULL), mutex(new OpenThreads::Mutex()),
-                    windowManager(new WindowManager())
-{
-    root->setName("OsgViz root");
+osg::ref_ptr<OsgViz> OsgViz::getExistingInstance(){
+	return getInstance();
 }
 
+OsgViz::OsgViz(int argc, char** argv){
+	init(argc,argv);
+}
+
+
+void OsgViz::init(int argc,char** argv){
+	//graphicsManager = new graphics::GraphicsManager(libmanager);
+
+	mutex = new OpenThreads::Mutex();
+
+	thread = NULL;
+	m_argc = argc;
+	m_argv = argv;
+	root = new osg::Group();
+	root->setName("OsgViz root");
+
+	windowManager = new WindowManager();
+
+}
 
 OsgViz::~OsgViz(){
 
-    for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
-        delete it->second;
-    }
+	for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
+		delete it->second;
+	}
 
-    delete mutex;
+	delete mutex;
+
+	//if (graphicsManager){
+	//	delete graphicsManager;
+	//}
+
 }
 
 unsigned int OsgViz::createWindow(WindowConfig windowConfig, osg::ref_ptr<osg::GraphicsContext> graphicsContext) {
-    unsigned int winID = windowManager->createWindow(windowConfig,NULL,graphicsContext);
+	//int id = graphicsManager->new3DWindow();
+	//mars::interfaces::GraphicsWindowInterface* window = this->get3DWindow(1);
+	unsigned int winID = windowManager->createWindow(windowConfig,NULL,graphicsContext);
 
-    // all created windows will share the same osgviz scene
-    windowManager->getWindowByID(winID)->addChild(root);
+	// all created windows will share the same osgviz scene
+	windowManager->getWindowByID(winID)->addChild(root);
 
-    return winID;
+	return winID;
 
 }
 
@@ -66,6 +87,8 @@ void OsgViz::destroyWindow(unsigned int id){
 }
 
 void OsgViz::update(){
+
+
     for (std::map<int, Updatable*>::reverse_iterator callback = updateCallbacks.rbegin(); callback != updateCallbacks.rend();++callback){
         callback->second->update();
     }
@@ -73,6 +96,8 @@ void OsgViz::update(){
     mutex->lock();
     windowManager->frame();
     mutex->unlock();
+
+
 }
 
 int OsgViz::addUpdateCallback(Updatable* callback, int priority) {
@@ -87,55 +112,56 @@ int OsgViz::addUpdateCallback(Updatable* callback, int priority) {
 
 
 void OsgViz::startThread(int microseconds){
-    if (!thread){
-        #ifndef WIN32
-            XInitThreads();
-        #endif
-        thread = new UpdateThread(this, microseconds);
-        thread->startThread();
-    }else{
-        fprintf(stderr,"thread already running\n");
-    }
+	if (!thread){
+		#ifndef WIN32
+			XInitThreads();
+		#endif
+		thread = new UpdateThread(this, microseconds);
+		thread->startThread();
+	}else{
+		fprintf(stderr,"thread already running\n");
+	}
 }
 
 void OsgViz::stopThread(){
-    if (thread){
-        thread->cancel();
-        delete thread;
-    }
+	if (thread){
+		thread->cancel();
+		delete thread;
+	}
 }
 
 
 void OsgViz::lockThread(){
-    if (thread){
-        thread->lock();
-    }else{
-        mutex->lock();
-    }
+	if (thread){
+		thread->lock();
+	}else{
+		mutex->lock();
+	}
 }
 
 void OsgViz::unlockThread(){
-    if (thread){
-        thread->unlock();
-    }else{
-        mutex->unlock();
-    }
+	if (thread){
+		thread->unlock();
+	}else{
+		mutex->unlock();
+	}
 }
 
 int OsgViz::tryLockThread(){
-    if (thread){
-        return thread->trylock();
-    }else{
-        return mutex->trylock();
-    }
-    return -1;
+	if (thread){
+		return thread->trylock();
+	}else{
+		return mutex->trylock();
+	}
+	return -1;
 }
 
 void OsgViz::printModules(){
-    for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
-        printf("%s : %s\n",it->first.c_str(),demangledTypeName(*(it->second)).c_str());
-    }
+	for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
+		printf("%s : %s\n",it->first.c_str(),demangledTypeName(*(it->second)).c_str());
+	}
 }
+
 }
 
 

--- a/src/OsgViz.cpp
+++ b/src/OsgViz.cpp
@@ -10,71 +10,54 @@
 #include <osgDB/WriteFile>
 #include <osgDB/Registry>
 
+#include <osgText/Font>
+
 #include "windows/WindowManager.h"
 #include "tools/TypeNameDemangling.h"
 
 namespace osgviz
 {
 
-osg::ref_ptr<OsgViz> instance = NULL;
 std::map<std::string, Module*> OsgViz::modules;
 
-osg::ref_ptr<OsgViz> OsgViz::getInstance(int argc,char** argv){
-	if (!instance.valid()){
-		instance = new OsgViz(argc,argv);
-	}
-	return instance;
+osg::ref_ptr<OsgViz> OsgViz::getInstance(){
+    
+    //HACK to work around a static destruction order bug: default font needs to be initialized before
+    //     OsgViz. Calling getDefaultFont() here ensures that the font is instanciated before 
+    //     OsgViz and thus lives longer than OsgViz and can still be called during OsgViz destruction.
+    osgText::Font::getDefaultFont();
+    //NOTE it is important that instance is a local static variable because we need a way to 
+    //     control static initialization/destruction order.
+    //     If instance is global the static initialization order depends on the order in which 
+    //     libraries are loaded which leads to strange crashes in combination with osg's own singletons
+    static osg::ref_ptr<OsgViz> instance = new OsgViz();
+    return instance;
 }
 
 
-osg::ref_ptr<OsgViz> OsgViz::getExistingInstance(){
-	return instance;
+OsgViz::OsgViz() : root(new osg::Group()), thread(NULL), mutex(new OpenThreads::Mutex()),
+                    windowManager(new WindowManager())
+{
+    root->setName("OsgViz root");
 }
 
-OsgViz::OsgViz(int argc, char** argv){
-	init(argc,argv);
-}
-
-
-void OsgViz::init(int argc,char** argv){
-	//graphicsManager = new graphics::GraphicsManager(libmanager);
-
-	mutex = new OpenThreads::Mutex();
-
-	thread = NULL;
-	m_argc = argc;
-	m_argv = argv;
-	root = new osg::Group();
-	root->setName("OsgViz root");
-	instance = this;
-
-	windowManager = new WindowManager();
-
-}
 
 OsgViz::~OsgViz(){
 
-	for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
-		delete it->second;
-	}
+    for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
+        delete it->second;
+    }
 
-	delete mutex;
-
-	//if (graphicsManager){
-	//	delete graphicsManager;
-	//}
-
+    delete mutex;
 }
 
 unsigned int OsgViz::createWindow(WindowConfig windowConfig, osg::ref_ptr<osg::GraphicsContext> graphicsContext) {
-	//int id = graphicsManager->new3DWindow();
-	//mars::interfaces::GraphicsWindowInterface* window = this->get3DWindow(1);
-	unsigned int winID = windowManager->createWindow(windowConfig,NULL,graphicsContext);
+    unsigned int winID = windowManager->createWindow(windowConfig,NULL,graphicsContext);
 
-	// all created windows will share the same osgviz scene
-	windowManager->getWindowByID(winID)->addChild(root);
+    // all created windows will share the same osgviz scene
+    windowManager->getWindowByID(winID)->addChild(root);
 
-	return winID;
+    return winID;
 
 }
 
@@ -83,8 +66,6 @@ void OsgViz::destroyWindow(unsigned int id){
 }
 
 void OsgViz::update(){
-
-
     for (std::map<int, Updatable*>::reverse_iterator callback = updateCallbacks.rbegin(); callback != updateCallbacks.rend();++callback){
         callback->second->update();
     }
@@ -92,8 +73,6 @@ void OsgViz::update(){
     mutex->lock();
     windowManager->frame();
     mutex->unlock();
-
-
 }
 
 int OsgViz::addUpdateCallback(Updatable* callback, int priority) {
@@ -108,56 +87,55 @@ int OsgViz::addUpdateCallback(Updatable* callback, int priority) {
 
 
 void OsgViz::startThread(int microseconds){
-	if (!thread){
-		#ifndef WIN32
-			XInitThreads();
-		#endif
-		thread = new UpdateThread(this, microseconds);
-		thread->startThread();
-	}else{
-		fprintf(stderr,"thread already running\n");
-	}
+    if (!thread){
+        #ifndef WIN32
+            XInitThreads();
+        #endif
+        thread = new UpdateThread(this, microseconds);
+        thread->startThread();
+    }else{
+        fprintf(stderr,"thread already running\n");
+    }
 }
 
 void OsgViz::stopThread(){
-	if (thread){
-		thread->cancel();
-		delete thread;
-	}
+    if (thread){
+        thread->cancel();
+        delete thread;
+    }
 }
 
 
 void OsgViz::lockThread(){
-	if (thread){
-		thread->lock();
-	}else{
-		mutex->lock();
-	}
+    if (thread){
+        thread->lock();
+    }else{
+        mutex->lock();
+    }
 }
 
 void OsgViz::unlockThread(){
-	if (thread){
-		thread->unlock();
-	}else{
-		mutex->unlock();
-	}
+    if (thread){
+        thread->unlock();
+    }else{
+        mutex->unlock();
+    }
 }
 
 int OsgViz::tryLockThread(){
-	if (thread){
-		return thread->trylock();
-	}else{
-		return mutex->trylock();
-	}
-	return -1;
+    if (thread){
+        return thread->trylock();
+    }else{
+        return mutex->trylock();
+    }
+    return -1;
 }
 
 void OsgViz::printModules(){
-	for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
-		printf("%s : %s\n",it->first.c_str(),demangledTypeName(*(it->second)).c_str());
-	}
+    for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
+        printf("%s : %s\n",it->first.c_str(),demangledTypeName(*(it->second)).c_str());
+    }
 }
-
 }
 
 

--- a/src/OsgViz.hpp
+++ b/src/OsgViz.hpp
@@ -31,173 +31,215 @@ namespace osgviz
  * this allows to load plugins as shared so all plugins can access each other on the same instances
  * In case this is not wanted, the plugin should implement a "Factory"
  */
-    class OsgViz: public Updatable, public osg::Referenced
-    {
+	class OsgViz: public Updatable, public osg::Referenced
+	{
 
-        public: 
+		public: 
 
-        /**This instance Methods should be called on normal main programs
-         * @return the OsgViz instance*/
-        static osg::ref_ptr<OsgViz> getInstance();
-        private:
-            
-        /** private constructor used by getInstance()  */
-        OsgViz();
-        
-        public:
-        ~OsgViz();
+	    /**
+	     * This instance Methods should be called on normal main programs
+	     * osgviz does not have any args, but they are forwarded to the plugins loaded by getPlugin()
+	     * @param argc
+	     * @param argv
+	     * @return the OsgViz instance
+	     */
+		static osg::ref_ptr<OsgViz> getInstance(int argc = 0,char** argv = NULL);
 
-        /**
-            * starts a thread calling the update() function.
-            * @note This will also initialize the xlib threading (XInitThreads()). This will break
-            *       when used together with qt or any other xlib based gui framework.
-            * @param microseconds number of microseconds to wait between the calls on update()
-            */
-        void startThread(int microseconds = 10000);
-        void stopThread();
+		/**
+		 * This method is meant for plugins to obtain the instance which is already loaded.
+         * If no instance exists, a new instance with default parameters is created
+		 * @return the OsgViz main
+		 */
+		static osg::ref_ptr<OsgViz> getExistingInstance();
 
-        /**
-            * tries to lock osgviz, no matter if threaded or not
-            * calls trylock on a OpenThreads::Mutex
-            * @return 0 if normal, -1 if errno set, errno code otherwise.
-            */
-        int tryLockThread();
+		private:
+		/**
+		 * private constructor used by getInstance()
+		 * @param argc
+		 * @param argv
+		 */
+		OsgViz(int argc, char** argv);
 
-        /**
-            * lock osgviz, no matter if threaded or not
-            */
-        void lockThread();
-
-        /**
-            * unlock osgviz, no matter if threaded or not
-            */
-        void unlockThread();
+		/**
+		 * init function with shared code for both constructors
+		 * @param argc
+		 * @param argv
+		 */
+		void init(int argc,char** argv);
 
 
-        /**
-            * render a new frame() in each window created by this instance
-            * automatically called if startThread() was called
-            */
-        virtual void update();
+		public:
+		~OsgViz();
 
-        /**
-            * creates a new window to display a scene
-            *
-            * the globel scene of osgviz is always displayed addChild()
-            * you can also add scenes to a single window by using the returned id and
-            * getWindowManager()->getWindowByID(int id)
-            *
-            * @param windowConfig window configuration, if a graphicsContext is given only ViewConfig settings are applied
-            * @param graphicsContext set an external osg::GraphicsContext for example a osgQt::GraphicsWindowQt
-            * @return window id, which can be used to obtain a osgviz::Window pointer getWindowManager()->getWindowByID(id);
-            */
-        unsigned int createWindow(WindowConfig windowConfig = WindowConfig(), osg::ref_ptr<osg::GraphicsContext> graphicsContext = NULL);
+		/**
+         * starts a thread calling the update() function.
+         * @note This will also initialize the xlib threading (XInitThreads()). This will break
+         *       when used together with qt or any other xlib based gui framework.
+		 * @param microseconds number of microseconds to wait between the calls on update()
+		 */
+	    void startThread(int microseconds = 10000);
+	    void stopThread();
 
-        /**
-            * removed a window
-            * @param id the id of the window to remove
-            */
+	    /**
+	     * tries to lock osgviz, no matter if threaded or not
+	     * calls trylock on a OpenThreads::Mutex
+	     * @return 0 if normal, -1 if errno set, errno code otherwise.
+	     */
+	    int tryLockThread();
+
+	    /**
+	     * lock osgviz, no matter if threaded or not
+	     */
+	    void lockThread();
+
+	    /**
+	     * unlock osgviz, no matter if threaded or not
+	     */
+	    void unlockThread();
+
+
+	    /**
+	     * render a new frame() in each window created by this instance
+	     * automatically called if startThread() was called
+	     */
+		virtual void update();
+
+		/**
+		 * creates a new window to display a scene
+		 *
+		 * the globel scene of osgviz is always displayed addChild()
+		 * you can also add scenes to a single window by using the returned id and
+		 * getWindowManager()->getWindowByID(int id)
+		 *
+		 * @param windowConfig window configuration, if a graphicsContext is given only ViewConfig settings are applied
+		 * @param graphicsContext set an external osg::GraphicsContext for example a osgQt::GraphicsWindowQt
+		 * @return window id, which can be used to obtain a osgviz::Window pointer getWindowManager()->getWindowByID(id);
+		 */
+		unsigned int createWindow(WindowConfig windowConfig = WindowConfig(), osg::ref_ptr<osg::GraphicsContext> graphicsContext = NULL);
+
+		/**
+		 * removed a window
+		 * @param id the id of the window to remove
+		 */
         void destroyWindow(unsigned int id);
 
 
         /**
-            * adds a callback which is called on each update() before the scened are rendered
-            * @param callback pointer to the  Updatable to be called.
-            * @param priority higher numbers are called first, if the priority is taken, the new one is placed after the existing
-            * @return the actual priority number the Updatable aquired
-            */
-        virtual int addUpdateCallback(Updatable* callback, int priority = 0);
+         * adds a callback which is called on each update() before the scened are rendered
+         * @param callback pointer to the  Updatable to be called.
+         * @param priority higher numbers are called first, if the priority is taken, the new one is placed after the existing
+         * @return the actual priority number the Updatable aquired
+         */
+		virtual int addUpdateCallback(Updatable* callback, int priority = 0);
 
 
-        /**
-            * loads an osgviz::Module class into the Inctance management of osgviz given a name
-            * Applications using osgviz can use the same instance of a Module identified by its name
-            * (same name/same instance)
-            * @ param moduleName The name of the instance to obtain (either existing or not)
-            * @ param argc The argument count passed to the Module (only for non-exixting instances)
-            * @ param argv The arguments passed to the Module (only for non-exixting instances)
-            */
-        template <class MODULE> static MODULE* getModuleInstance(std::string moduleName, int argc = 0, char **argv = NULL){
-            Module* mod;
-            mod = modules[moduleName];
-            if (! mod){
-                mod = new MODULE();
-                modules[moduleName] = mod;
-                mod->init(argc,argv);
-            }
-            return dynamic_cast<MODULE*>(mod);
-        }
+		/**
+		 * loads an osgviz::Module class into the Inctance management of osgviz given a name
+		 * Applications using osgviz can use the same instance of a Module identified by its name
+		 * (same name/same instance)
+		 * @ param moduleName The name of the instance to obtain (either existing or not)
+		 * @ param argc The argument count passed to the Module (only for non-exixting instances)
+		 * @ param argv The arguments passed to the Module (only for non-exixting instances)
+		 */
+		template <class MODULE> static MODULE* getModuleInstance(std::string moduleName, int argc = 0, char **argv = NULL){
+			Module* mod;
+			mod = modules[moduleName];
+			if (! mod){
+				mod = new MODULE();
+				modules[moduleName] = mod;
+				mod->init(argc,argv);
+			}
+			return dynamic_cast<MODULE*>(mod);
+		}
 
-        /**
-            * print available module names and classes
-            */
-        static void printModules();
+		/**
+		 * print available module names and classes
+		 */
+		static void printModules();
 
-        /**
-            * return the osgviz globally shared scene
-            * This node is added by default in each window created
-            * If you want different contents, call osgviz::Window::getRootNode()
-            * @return the global root node
-            */
-        inline osg::ref_ptr<osg::Group> getRootNode(){
-            return root;
-        }
+		/**
+		 * return the osgviz globally shared scene
+		 * This node is added by default in each window created
+		 * If you want different contents, call osgviz::Window::getRootNode()
+		 * @return the global root node
+		 */
+		inline osg::ref_ptr<osg::Group> getRootNode(){
+			return root;
+		}
 
-        /**
-            * add a child to the globally shared scene
-            * these nodes are shared across all windows created
-            * If you want different contents, call osgviz::Window::getRootNode()
-            * @param node ht enode to add to the shared scene
-            */
-        inline void addChild(osg::Node * node){
-            root->addChild(node);
-        }
+		/**
+		 * add a child to the globally shared scene
+		 * these nodes are shared across all windows created
+		 * If you want different contents, call osgviz::Window::getRootNode()
+		 * @param node ht enode to add to the shared scene
+		 */
+		inline void addChild(osg::Node * node){
+			root->addChild(node);
+		}
 
-        /**
-            * replace the shred scene
-            * @param node the node to replaced all previous objects
-            */
+		/**
+		 * replace the shred scene
+		 * @param node the node to replaced all previous objects
+		 */
         inline void setScene(osg::Node * node){
             root->removeChildren(0,root->getNumChildren());
             root->addChild(node);
         }
 
         /**
-            * get a child of the root node
-            * @param index
-            * @return
-            */
+         * get a child of the root node
+         * @param index
+         * @return
+         */
         inline osg::Node* getChild(int index = 0){
             return root->getChild(index);
         }
 
         /**
-            * save the (globally shared) scene displayed to a file
-            * @param name
-            */
-        inline void write(const char* name){
-            osgDB::writeNodeFile(*root, name);
-        }
+         * save the (globally shared) scene displayed to a file
+         * @param name
+         */
+		inline void write(const char* name){
+			osgDB::writeNodeFile(*root, name);
+		}
 
-        /**
-            * get a pointer to the windowManager which gived access to single windows and their scenes
-            * @return the osgviz::WindowManager
-            */
-        inline WindowManager* getWindowManager(){
-            return windowManager.get();
-        }
+		/**
+		 * get a pointer to the windowManager which gived access to single windows and their scenes
+		 * @return the osgviz::WindowManager
+		 */
+		inline WindowManager* getWindowManager(){
+			return windowManager.get();
+		}
 
 
-    private:
-            
-        osg::ref_ptr<osg::Group> root;
-        static std::map<std::string, Module*> modules;
-        UpdateThread* thread;
-        OpenThreads::Mutex* mutex;
-        osg::ref_ptr<WindowManager> windowManager;
-        std::map<int, Updatable*> updateCallbacks;
+		private:
 
-    };
+		osg::ref_ptr<osg::Group> root;
+		bool initialized;
+		static std::map<std::string, Module*> modules;
+
+		int m_argc;
+		char** m_argv;
+
+
+		UpdateThread* thread;
+
+		OpenThreads::Mutex* mutex;
+
+		//graphics::GraphicsManager* graphicsManager;
+		//osgViewer::Viewer viewer;
+		//std::vector<osgViewer::Viewer *> viewers;
+
+		osg::ref_ptr<WindowManager> windowManager;
+
+
+		std::map<int, Updatable*> updateCallbacks;
+
+	};
+
+
+
+
 } // end namespace osgviz
 
 #endif // _DUMMYPROJECT_DUMMY_HPP_

--- a/src/OsgViz.hpp
+++ b/src/OsgViz.hpp
@@ -31,214 +31,173 @@ namespace osgviz
  * this allows to load plugins as shared so all plugins can access each other on the same instances
  * In case this is not wanted, the plugin should implement a "Factory"
  */
-	class OsgViz: public Updatable, public osg::Referenced
-	{
+    class OsgViz: public Updatable, public osg::Referenced
+    {
 
-		public: 
+        public: 
 
-	    /**
-	     * This instance Methods should be called on normal main programs
-	     * osgviz does not have any args, but they are forwarded to the plugins loaded by getPlugin()
-	     * @param argc
-	     * @param argv
-	     * @return the OsgViz instance
-	     */
-		static osg::ref_ptr<OsgViz> getInstance(int argc = 0,char** argv = NULL);
+        /**This instance Methods should be called on normal main programs
+         * @return the OsgViz instance*/
+        static osg::ref_ptr<OsgViz> getInstance();
+        private:
+            
+        /** private constructor used by getInstance()  */
+        OsgViz();
+        
+        public:
+        ~OsgViz();
 
-		/**
-		 * This method is meant for plugins to obtain the instance which is already loaded
-		 * @return the OsgViz main
-		 */
-		static osg::ref_ptr<OsgViz> getExistingInstance();
+        /**
+            * starts a thread calling the update() function.
+            * @note This will also initialize the xlib threading (XInitThreads()). This will break
+            *       when used together with qt or any other xlib based gui framework.
+            * @param microseconds number of microseconds to wait between the calls on update()
+            */
+        void startThread(int microseconds = 10000);
+        void stopThread();
 
-		private:
-		/**
-		 * private constructor used by getInstance()
-		 * @param argc
-		 * @param argv
-		 */
-		OsgViz(int argc, char** argv);
+        /**
+            * tries to lock osgviz, no matter if threaded or not
+            * calls trylock on a OpenThreads::Mutex
+            * @return 0 if normal, -1 if errno set, errno code otherwise.
+            */
+        int tryLockThread();
 
-		/**
-		 * init function with shared code for both constructors
-		 * @param argc
-		 * @param argv
-		 */
-		void init(int argc,char** argv);
+        /**
+            * lock osgviz, no matter if threaded or not
+            */
+        void lockThread();
 
-
-		public:
-		~OsgViz();
-
-		/**
-         * starts a thread calling the update() function.
-         * @note This will also initialize the xlib threading (XInitThreads()). This will break
-         *       when used together with qt or any other xlib based gui framework.
-		 * @param microseconds number of microseconds to wait between the calls on update()
-		 */
-	    void startThread(int microseconds = 10000);
-	    void stopThread();
-
-	    /**
-	     * tries to lock osgviz, no matter if threaded or not
-	     * calls trylock on a OpenThreads::Mutex
-	     * @return 0 if normal, -1 if errno set, errno code otherwise.
-	     */
-	    int tryLockThread();
-
-	    /**
-	     * lock osgviz, no matter if threaded or not
-	     */
-	    void lockThread();
-
-	    /**
-	     * unlock osgviz, no matter if threaded or not
-	     */
-	    void unlockThread();
+        /**
+            * unlock osgviz, no matter if threaded or not
+            */
+        void unlockThread();
 
 
-	    /**
-	     * render a new frame() in each window created by this instance
-	     * automatically called if startThread() was called
-	     */
-		virtual void update();
+        /**
+            * render a new frame() in each window created by this instance
+            * automatically called if startThread() was called
+            */
+        virtual void update();
 
-		/**
-		 * creates a new window to display a scene
-		 *
-		 * the globel scene of osgviz is always displayed addChild()
-		 * you can also add scenes to a single window by using the returned id and
-		 * getWindowManager()->getWindowByID(int id)
-		 *
-		 * @param windowConfig window configuration, if a graphicsContext is given only ViewConfig settings are applied
-		 * @param graphicsContext set an external osg::GraphicsContext for example a osgQt::GraphicsWindowQt
-		 * @return window id, which can be used to obtain a osgviz::Window pointer getWindowManager()->getWindowByID(id);
-		 */
-		unsigned int createWindow(WindowConfig windowConfig = WindowConfig(), osg::ref_ptr<osg::GraphicsContext> graphicsContext = NULL);
+        /**
+            * creates a new window to display a scene
+            *
+            * the globel scene of osgviz is always displayed addChild()
+            * you can also add scenes to a single window by using the returned id and
+            * getWindowManager()->getWindowByID(int id)
+            *
+            * @param windowConfig window configuration, if a graphicsContext is given only ViewConfig settings are applied
+            * @param graphicsContext set an external osg::GraphicsContext for example a osgQt::GraphicsWindowQt
+            * @return window id, which can be used to obtain a osgviz::Window pointer getWindowManager()->getWindowByID(id);
+            */
+        unsigned int createWindow(WindowConfig windowConfig = WindowConfig(), osg::ref_ptr<osg::GraphicsContext> graphicsContext = NULL);
 
-		/**
-		 * removed a window
-		 * @param id the id of the window to remove
-		 */
+        /**
+            * removed a window
+            * @param id the id of the window to remove
+            */
         void destroyWindow(unsigned int id);
 
 
         /**
-         * adds a callback which is called on each update() before the scened are rendered
-         * @param callback pointer to the  Updatable to be called.
-         * @param priority higher numbers are called first, if the priority is taken, the new one is placed after the existing
-         * @return the actual priority number the Updatable aquired
-         */
-		virtual int addUpdateCallback(Updatable* callback, int priority = 0);
+            * adds a callback which is called on each update() before the scened are rendered
+            * @param callback pointer to the  Updatable to be called.
+            * @param priority higher numbers are called first, if the priority is taken, the new one is placed after the existing
+            * @return the actual priority number the Updatable aquired
+            */
+        virtual int addUpdateCallback(Updatable* callback, int priority = 0);
 
 
-		/**
-		 * loads an osgviz::Module class into the Inctance management of osgviz given a name
-		 * Applications using osgviz can use the same instance of a Module identified by its name
-		 * (same name/same instance)
-		 * @ param moduleName The name of the instance to obtain (either existing or not)
-		 * @ param argc The argument count passed to the Module (only for non-exixting instances)
-		 * @ param argv The arguments passed to the Module (only for non-exixting instances)
-		 */
-		template <class MODULE> static MODULE* getModuleInstance(std::string moduleName, int argc = 0, char **argv = NULL){
-			Module* mod;
-			mod = modules[moduleName];
-			if (! mod){
-				mod = new MODULE();
-				modules[moduleName] = mod;
-				mod->init(argc,argv);
-			}
-			return dynamic_cast<MODULE*>(mod);
-		}
+        /**
+            * loads an osgviz::Module class into the Inctance management of osgviz given a name
+            * Applications using osgviz can use the same instance of a Module identified by its name
+            * (same name/same instance)
+            * @ param moduleName The name of the instance to obtain (either existing or not)
+            * @ param argc The argument count passed to the Module (only for non-exixting instances)
+            * @ param argv The arguments passed to the Module (only for non-exixting instances)
+            */
+        template <class MODULE> static MODULE* getModuleInstance(std::string moduleName, int argc = 0, char **argv = NULL){
+            Module* mod;
+            mod = modules[moduleName];
+            if (! mod){
+                mod = new MODULE();
+                modules[moduleName] = mod;
+                mod->init(argc,argv);
+            }
+            return dynamic_cast<MODULE*>(mod);
+        }
 
-		/**
-		 * print available module names and classes
-		 */
-		static void printModules();
+        /**
+            * print available module names and classes
+            */
+        static void printModules();
 
-		/**
-		 * return the osgviz globally shared scene
-		 * This node is added by default in each window created
-		 * If you want different contents, call osgviz::Window::getRootNode()
-		 * @return the global root node
-		 */
-		inline osg::ref_ptr<osg::Group> getRootNode(){
-			return root;
-		}
+        /**
+            * return the osgviz globally shared scene
+            * This node is added by default in each window created
+            * If you want different contents, call osgviz::Window::getRootNode()
+            * @return the global root node
+            */
+        inline osg::ref_ptr<osg::Group> getRootNode(){
+            return root;
+        }
 
-		/**
-		 * add a child to the globally shared scene
-		 * these nodes are shared across all windows created
-		 * If you want different contents, call osgviz::Window::getRootNode()
-		 * @param node ht enode to add to the shared scene
-		 */
-		inline void addChild(osg::Node * node){
-			root->addChild(node);
-		}
+        /**
+            * add a child to the globally shared scene
+            * these nodes are shared across all windows created
+            * If you want different contents, call osgviz::Window::getRootNode()
+            * @param node ht enode to add to the shared scene
+            */
+        inline void addChild(osg::Node * node){
+            root->addChild(node);
+        }
 
-		/**
-		 * replace the shred scene
-		 * @param node the node to replaced all previous objects
-		 */
+        /**
+            * replace the shred scene
+            * @param node the node to replaced all previous objects
+            */
         inline void setScene(osg::Node * node){
             root->removeChildren(0,root->getNumChildren());
             root->addChild(node);
         }
 
         /**
-         * get a child of the root node
-         * @param index
-         * @return
-         */
+            * get a child of the root node
+            * @param index
+            * @return
+            */
         inline osg::Node* getChild(int index = 0){
             return root->getChild(index);
         }
 
         /**
-         * save the (globally shared) scene displayed to a file
-         * @param name
-         */
-		inline void write(const char* name){
-			osgDB::writeNodeFile(*root, name);
-		}
+            * save the (globally shared) scene displayed to a file
+            * @param name
+            */
+        inline void write(const char* name){
+            osgDB::writeNodeFile(*root, name);
+        }
 
-		/**
-		 * get a pointer to the windowManager which gived access to single windows and their scenes
-		 * @return the osgviz::WindowManager
-		 */
-		inline WindowManager* getWindowManager(){
-			return windowManager.get();
-		}
-
-
-		private:
-
-		osg::ref_ptr<osg::Group> root;
-		bool initialized;
-		static std::map<std::string, Module*> modules;
-
-		int m_argc;
-		char** m_argv;
+        /**
+            * get a pointer to the windowManager which gived access to single windows and their scenes
+            * @return the osgviz::WindowManager
+            */
+        inline WindowManager* getWindowManager(){
+            return windowManager.get();
+        }
 
 
-		UpdateThread* thread;
+    private:
+            
+        osg::ref_ptr<osg::Group> root;
+        static std::map<std::string, Module*> modules;
+        UpdateThread* thread;
+        OpenThreads::Mutex* mutex;
+        osg::ref_ptr<WindowManager> windowManager;
+        std::map<int, Updatable*> updateCallbacks;
 
-		OpenThreads::Mutex* mutex;
-
-		//graphics::GraphicsManager* graphicsManager;
-		//osgViewer::Viewer viewer;
-		//std::vector<osgViewer::Viewer *> viewers;
-
-		osg::ref_ptr<WindowManager> windowManager;
-
-
-		std::map<int, Updatable*> updateCallbacks;
-
-	};
-
-
-
-
+    };
 } // end namespace osgviz
 
 #endif // _DUMMYPROJECT_DUMMY_HPP_


### PR DESCRIPTION
Parts of the osg scene graph depend on the osgText::DefaultFont singleton to exist upon destruction.
Depending on the order of library loads sometimes the osg singleton was destroyed before osgviz thus resulting in a segfault when destroying osgviz.

This patch ensures that osgviz is always destroyed first.