### PR TITLE
Make windows resizable

### DIFF
--- a/src/windows/WindowManager.cpp
+++ b/src/windows/WindowManager.cpp
@@ -68,7 +68,7 @@ void WindowManager::frame() {
 osg::ref_ptr<osg::GraphicsContext::Traits> WindowManager::genetrateTraits(WindowConfig& windowConfig){
     osg::ref_ptr<osg::GraphicsContext::Traits> traits = new osg::GraphicsContext::Traits;
     traits->windowName = windowConfig.title;
-    traits->supportsResize = false;
+    traits->supportsResize = true;
     traits->doubleBuffer = true;
     traits->sharedContext = 0;
 


### PR DESCRIPTION
Is there a reason why windows are not be resizable?

I guess, ideally this should be configurable via the `WindowConfig` (then we could keep the default as `false`, if this change breaks anything).