### PR TITLE
Typeless modules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,7 +138,7 @@ rock_library(ModelLoader
     DEPS osgViz)
     
 rock_executable(osgViz_bin Main.cpp
-    DEPS osgViz PrimitivesFactory
+    DEPS osgViz PrimitivesFactory ModelLoader
     LIBS ${ADDITIONAL_LIBS})
 
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -42,11 +42,11 @@ int main(int argc, char** argv)
 	//load lib with some helpful primitives
 	printf("load plugin\n");	fflush(stdout);
 	//osgviz::PrimitivesFactory *primitivesfactory = new osgviz::PrimitivesFactory(NULL);
-	osgviz::PrimitivesFactory *primitivesfactory = osgviz::OsgViz::getModuleInstance<osgviz::PrimitivesFactory>("PrimitivesFactory");
+	std::shared_ptr<osgviz::PrimitivesFactory> primitivesfactory = osgviz::OsgViz::getModuleInstance<osgviz::PrimitivesFactory>("PrimitivesFactory");
 
-	osgviz::PrimitivesFactory *primitivesfactory2 = osgviz::OsgViz::getModuleInstance<osgviz::PrimitivesFactory>("PrimitivesFactory");
+	std::shared_ptr<osgviz::PrimitivesFactory> primitivesfactory2 = osgviz::OsgViz::getModuleInstance<osgviz::PrimitivesFactory>("PrimitivesFactory");
 
-	osgviz::PrimitivesFactory *primitivesfactory3 = osgviz::OsgViz::getModuleInstance<osgviz::PrimitivesFactory>("PrimitivesFactory2");
+	std::shared_ptr<osgviz::PrimitivesFactory> primitivesfactory3 = osgviz::OsgViz::getModuleInstance<osgviz::PrimitivesFactory>("PrimitivesFactory2");
 
 	osgviz::OsgViz::printModules();
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "OsgViz.hpp"
 #include "modules/viz/Primitives/PrimitivesFactory.h"
+#include "modules/viz/ModelLoader/ModelLoader.h"
 
 
 #ifndef WIN32
@@ -48,6 +49,14 @@ int main(int argc, char** argv)
 
 	std::shared_ptr<osgviz::PrimitivesFactory> primitivesfactory3 = osgviz::OsgViz::getModuleInstance<osgviz::PrimitivesFactory>("PrimitivesFactory2");
 
+        try {
+            std::shared_ptr<osgviz::ModelLoader> primitivesfactory3 = osgviz::OsgViz::getModuleInstance<osgviz::ModelLoader>("PrimitivesFactory2");
+        
+        } catch (std::runtime_error e){
+            printf("%s\n", e.what());
+        }
+                        
+        
 	osgviz::OsgViz::printModules();
 
 	printf("PF \n\t%p \n\t%p\n\t%p\n",primitivesfactory,primitivesfactory2,primitivesfactory3);

--- a/src/Module.h
+++ b/src/Module.h
@@ -15,22 +15,30 @@
 
 namespace osgviz{
 
-class Module{
+struct ModuleBase{
+    ModuleBase(){};
+    virtual ~ModuleBase(){};
+};
+
+template <class T> class Module: public ModuleBase{
 
 public:
 
-	virtual ~Module(){};
+    Module(const std::shared_ptr<T>& module):module(module){};
+    virtual ~Module(){};
 
     /**
      * init is called after loading the plugin using
      * osgviz::getPlugin
      */
-    virtual void init(int argc,char** argv){};
+    //virtual void init(int argc,char** argv){};
 
 
 protected:
     friend class OsgViz;
+    Module(int argc,char** argv){};
     Module(){};
+    std::shared_ptr<T> module;
 
 };
 

--- a/src/Module.h
+++ b/src/Module.h
@@ -36,9 +36,12 @@ public:
 
 protected:
     friend class OsgViz;
-    Module(int argc,char** argv){};
-    Module(){};
     std::shared_ptr<T> module;
+
+private:
+    //Module(int argc,char** argv){};
+    Module(){};
+    
 
 };
 

--- a/src/OsgViz.cpp
+++ b/src/OsgViz.cpp
@@ -154,9 +154,9 @@ int OsgViz::tryLockThread(){
 }
 
 void OsgViz::printModules(){
-// 	for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
-// 		printf("%s : %s\n",it->first.c_str(),demangledTypeName(*(it->second)).c_str());
-// 	}
+ 	for (std::map<std::string, std::unique_ptr< struct ModuleBase > >::iterator it = modules.begin();it!=modules.end();it++){
+ 		printf("%s\t : %s\n",it->first.c_str(),demangledTypeName(*(it->second)).c_str());
+ 	}
 }
 
 }

--- a/src/OsgViz.cpp
+++ b/src/OsgViz.cpp
@@ -16,7 +16,7 @@
 namespace osgviz
 {
 
-std::map<std::string, Module*> OsgViz::modules;
+std::map<std::string, std::unique_ptr< struct ModuleBase> > OsgViz::modules;
 
 osg::ref_ptr<OsgViz> OsgViz::getInstance(int argc,char** argv){
     //HACK to work around a static destruction order bug: default font needs to be initialized before
@@ -58,9 +58,6 @@ void OsgViz::init(int argc,char** argv){
 
 OsgViz::~OsgViz(){
 
-	for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
-		delete it->second;
-	}
 
 	delete mutex;
 
@@ -157,9 +154,9 @@ int OsgViz::tryLockThread(){
 }
 
 void OsgViz::printModules(){
-	for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
-		printf("%s : %s\n",it->first.c_str(),demangledTypeName(*(it->second)).c_str());
-	}
+// 	for (std::map<std::string, Module*>::iterator it = modules.begin();it!=modules.end();it++){
+// 		printf("%s : %s\n",it->first.c_str(),demangledTypeName(*(it->second)).c_str());
+// 	}
 }
 
 }

--- a/src/modules/viz/ModelLoader/ModelLoader.cpp
+++ b/src/modules/viz/ModelLoader/ModelLoader.cpp
@@ -9,14 +9,13 @@
 #include <osgDB/ReadFile>
 #include <osg/Node>
 
-#include "../../../OsgViz.hpp"
 
 
 
 namespace osgviz {
 
 
-ModelLoader::ModelLoader():Module() {
+ModelLoader::ModelLoader(int argc, char** argv) {
 
 
 
@@ -25,14 +24,6 @@ ModelLoader::ModelLoader():Module() {
 ModelLoader::~ModelLoader() {
 	// TODO Auto-generated destructor stub
 }
-
-
-void ModelLoader::init(int argc, char** argv){
-
-	//modelfactory = getParent()->getVisualizerPlugin<ModelViewFactory>("ModelViewFactory");
-
-}
-
 
 osg::ref_ptr<Object> ModelLoader::loadModel(std::string path){
 	printf("load %s\n",path.c_str());

--- a/src/modules/viz/ModelLoader/ModelLoader.h
+++ b/src/modules/viz/ModelLoader/ModelLoader.h
@@ -8,16 +8,14 @@
 #ifndef GUI_OSGVIZ_SRC_PLUGINS_DATA_MODELLOADER_H_
 #define GUI_OSGVIZ_SRC_PLUGINS_DATA_MODELLOADER_H_
 
-#include "../../../Module.h"
+#include "../../../Object.h"
 
 namespace osgviz {
 
-class ModelLoader : public Module{
+class ModelLoader{
 public:
-	ModelLoader();
+	ModelLoader(int argc = 0, char** argv = nullptr);
 	virtual ~ModelLoader();
-
-	virtual void init(int argc, char** argv);
 
 	virtual osg::ref_ptr<Object> loadModel(std::string path);
 

--- a/src/modules/viz/Primitives/PrimitivesFactory.cpp
+++ b/src/modules/viz/Primitives/PrimitivesFactory.cpp
@@ -33,7 +33,7 @@ namespace osgviz {
 
 //OSGVIZ_PLUGIN(PrimitivesFactory);
 
-PrimitivesFactory::PrimitivesFactory():Module() {}
+PrimitivesFactory::PrimitivesFactory(int argc, char** argv) {}
 
 PrimitivesFactory::~PrimitivesFactory() {}
 

--- a/src/modules/viz/Primitives/PrimitivesFactory.h
+++ b/src/modules/viz/Primitives/PrimitivesFactory.h
@@ -10,14 +10,14 @@
 
 #include <osg/Shape>
 #include <osg/ShapeDrawable>
-#include "../../../Module.h"
+#include "../../../Object.h"
 #include <vector>
 
 namespace osgviz {
 
-class PrimitivesFactory: public Module {
+class PrimitivesFactory {
 public:
-    PrimitivesFactory();
+    PrimitivesFactory(int argc = 0, char** argv = nullptr);
     virtual ~PrimitivesFactory();
 
     virtual int getLibVersion() const {return 0;};


### PR DESCRIPTION
This PR changes the interface of the module instance management to use std::shared_ptr.
Also, the managed modules don't have to inherit from osgviz::Module anymore, all they need is a (argc,argv) constructor, the modules can be implemented and used without an osgviz dependency

The module management makes it possible to treat any module as singleton instance, nevertheless the modules can also be used as normal libraries without using the management.

@arneboe this affects https://github.com/rock-core/gui-vizkit3d/pull/34
