### PR TITLE
Fix catch-value and format warnings.

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
 
     osgviz::OsgViz::printModules();
 
-    printf("PF \n\t%p \n\t%p\n\t%p\n",primitivesfactory,primitivesfactory2,primitivesfactory3);
+    printf("PF \n\t%p \n\t%p\n\t%p\n", primitivesfactory.get(), primitivesfactory2.get(), primitivesfactory3.get());
 
     if (!primitivesfactory){
         printf("plugin not found\n");	fflush(stdout);

--- a/src/OsgViz.hpp
+++ b/src/OsgViz.hpp
@@ -159,7 +159,7 @@ namespace osgviz
             try {
                 Module<MOD>& mod = dynamic_cast< Module<MOD>& > (*base);
                 return mod.module;
-            } catch (std::bad_cast e) {
+            } catch (std::bad_cast const& e) {
                 std::string message = " there is no module '" +
                     moduleName + "' of type '" +
 #if(WIN32)


### PR DESCRIPTION
The arguments to `printf` were `shared_ptr` and not primitive pointers.
Also it is generally recommended to catch by const reference.